### PR TITLE
Support Changing Background Color and Opacity (Fabric)

### DIFF
--- a/fabric/src/main/java/me/boxadactle/coordinatesdisplay/gui/config/ColorConfigScreen.java
+++ b/fabric/src/main/java/me/boxadactle/coordinatesdisplay/gui/config/ColorConfigScreen.java
@@ -111,6 +111,8 @@ public class ColorConfigScreen extends Screen {
         drawTextWithShadow(matrices, this.textRenderer, Text.literal("Definition Color"), this.width / 2 - smallButtonW, start + 8, ModUtils.WHITE);
         drawTextWithShadow(matrices, this.textRenderer, Text.literal("Data Color"), this.width / 2, start + 8, ModUtils.WHITE);
         drawTextWithShadow(matrices, this.textRenderer, Text.literal("Death Position Color"), this.width / 2 - smallButtonW - p, start + 8 + (buttonHeight + p) * 2, ModUtils.WHITE);
+        drawTextWithShadow(matrices, this.textRenderer, Text.literal("Background Color (ARGB)"), this.width / 2 - smallButtonW, start + 8 + (buttonHeight + p) * 4, ModUtils.WHITE);
+        drawTextWithShadow(matrices, this.textRenderer, Text.literal("Background Opacity"), this.width / 2, start + 8 + (buttonHeight + p) * 4, ModUtils.WHITE);
 
         CoordinatesDisplay.OVERLAY.render(matrices, pos, chunkPos, cameraYaw, null, this.width / 2 - CoordinatesDisplay.OVERLAY.getWidth() - 5, y);
 
@@ -144,14 +146,21 @@ public class ColorConfigScreen extends Screen {
         TextFieldWidget definitionColor = new TextFieldWidget(this.textRenderer, this.width / 2 - smallButtonW - p, start + (buttonHeight + p), smallButtonW, buttonHeight, Text.literal(Integer.toHexString(CoordinatesDisplay.CONFIG.definitionColor)));
         TextFieldWidget dataColor = new TextFieldWidget(this.textRenderer, this.width / 2 + p, start + (buttonHeight + p), smallButtonW, buttonHeight, Text.literal(Integer.toHexString(CoordinatesDisplay.CONFIG.definitionColor)));
         TextFieldWidget deathposColor = new TextFieldWidget(this.textRenderer, this.width / 2 - smallButtonW - p, start + (buttonHeight + p) * 3, smallButtonW, buttonHeight, Text.literal(Integer.toHexString(CoordinatesDisplay.CONFIG.definitionColor)));
+        // Could not figure out how to get ARGB or RGBA working so split color and opacity into their own fields
+        TextFieldWidget backgroundColor = new TextFieldWidget(this.textRenderer, this.width / 2 - smallButtonW - p, start + (buttonHeight + p) * 5, smallButtonW, buttonHeight, Text.literal(Integer.toHexString(CoordinatesDisplay.CONFIG.definitionColor)));
+        TextFieldWidget backgroundOpacity = new TextFieldWidget(this.textRenderer, this.width / 2 + p, start + (buttonHeight + p) * 5, smallButtonW, buttonHeight, Text.literal(Integer.toHexString(CoordinatesDisplay.CONFIG.definitionColor)));
 
         definitionColor.setMaxLength(6);
         dataColor.setMaxLength(6);
         deathposColor.setMaxLength(6);
+        backgroundColor.setMaxLength(6);
+        backgroundOpacity.setMaxLength(2);
 
         definitionColor.setText(Integer.toHexString(CoordinatesDisplay.CONFIG.definitionColor));
         dataColor.setText(Integer.toHexString(CoordinatesDisplay.CONFIG.dataColor));
         deathposColor.setText(Integer.toHexString(CoordinatesDisplay.CONFIG.deathPosColor));
+        backgroundColor.setText(Integer.toHexString(CoordinatesDisplay.CONFIG.backgroundColor));
+        backgroundOpacity.setText(Integer.toHexString(CoordinatesDisplay.CONFIG.backgroundOpacity));
 
         definitionColor.setChangedListener((txt) -> {
             if (txt.isEmpty()) return;
@@ -183,9 +192,31 @@ public class ColorConfigScreen extends Screen {
             }
         });
 
+        backgroundColor.setChangedListener((txt) -> {
+            if (txt.isEmpty()) return;
+            try {
+                CoordinatesDisplay.CONFIG.backgroundColor = Integer.valueOf(txt.replaceAll("#", ""), 16);
+            } catch (NumberFormatException e) {
+                CoordinatesDisplay.LOGGER.error("Why you put invalid hex code?");
+                CoordinatesDisplay.LOGGER.printStackTrace(e);
+            }
+        });
+
+        backgroundOpacity.setChangedListener((txt) -> {
+            if (txt.isEmpty()) return;
+            try {
+                CoordinatesDisplay.CONFIG.backgroundOpacity = Integer.valueOf(txt.replaceAll("#", ""), 16);
+            } catch (NumberFormatException e) {
+                CoordinatesDisplay.LOGGER.error("Why you put invalid hex code?");
+                CoordinatesDisplay.LOGGER.printStackTrace(e);
+            }
+        });
+
         this.addDrawableChild(definitionColor);
         this.addDrawableChild(dataColor);
         this.addDrawableChild(deathposColor);
+        this.addDrawableChild(backgroundColor);
+        this.addDrawableChild(backgroundOpacity);
 
         this.addDrawableChild(new PressableTextWidget(this.width / 2 + p1, start + (buttonHeight + p) * 3, smallButtonW, buttonHeight, Text.literal("Color Picker..."), (button -> {
             Util.getOperatingSystem().open("https://htmlcolorcodes.com/color-picker/");

--- a/fabric/src/main/java/me/boxadactle/coordinatesdisplay/gui/config/ColorConfigScreen.java
+++ b/fabric/src/main/java/me/boxadactle/coordinatesdisplay/gui/config/ColorConfigScreen.java
@@ -111,8 +111,7 @@ public class ColorConfigScreen extends Screen {
         drawTextWithShadow(matrices, this.textRenderer, Text.literal("Definition Color"), this.width / 2 - smallButtonW, start + 8, ModUtils.WHITE);
         drawTextWithShadow(matrices, this.textRenderer, Text.literal("Data Color"), this.width / 2, start + 8, ModUtils.WHITE);
         drawTextWithShadow(matrices, this.textRenderer, Text.literal("Death Position Color"), this.width / 2 - smallButtonW - p, start + 8 + (buttonHeight + p) * 2, ModUtils.WHITE);
-        drawTextWithShadow(matrices, this.textRenderer, Text.literal("Background Color"), this.width / 2 - smallButtonW, start + 8 + (buttonHeight + p) * 4, ModUtils.WHITE);
-        drawTextWithShadow(matrices, this.textRenderer, Text.literal("Background Opacity"), this.width / 2, start + 8 + (buttonHeight + p) * 4, ModUtils.WHITE);
+        drawTextWithShadow(matrices, this.textRenderer, Text.literal("Background Color (ARGB)"), this.width / 2, start + 8 + (buttonHeight + p) * 2, ModUtils.WHITE);
 
         CoordinatesDisplay.OVERLAY.render(matrices, pos, chunkPos, cameraYaw, null, this.width / 2 - CoordinatesDisplay.OVERLAY.getWidth() - 5, y);
 
@@ -146,21 +145,17 @@ public class ColorConfigScreen extends Screen {
         TextFieldWidget definitionColor = new TextFieldWidget(this.textRenderer, this.width / 2 - smallButtonW - p, start + (buttonHeight + p), smallButtonW, buttonHeight, Text.literal(Integer.toHexString(CoordinatesDisplay.CONFIG.definitionColor)));
         TextFieldWidget dataColor = new TextFieldWidget(this.textRenderer, this.width / 2 + p, start + (buttonHeight + p), smallButtonW, buttonHeight, Text.literal(Integer.toHexString(CoordinatesDisplay.CONFIG.definitionColor)));
         TextFieldWidget deathposColor = new TextFieldWidget(this.textRenderer, this.width / 2 - smallButtonW - p, start + (buttonHeight + p) * 3, smallButtonW, buttonHeight, Text.literal(Integer.toHexString(CoordinatesDisplay.CONFIG.definitionColor)));
-        // Could not figure out how to get ARGB or RGBA working so split color and opacity into their own fields
-        TextFieldWidget backgroundColor = new TextFieldWidget(this.textRenderer, this.width / 2 - smallButtonW - p, start + (buttonHeight + p) * 5, smallButtonW, buttonHeight, Text.literal(Integer.toHexString(CoordinatesDisplay.CONFIG.definitionColor)));
-        TextFieldWidget backgroundOpacity = new TextFieldWidget(this.textRenderer, this.width / 2 + p, start + (buttonHeight + p) * 5, smallButtonW, buttonHeight, Text.literal(Integer.toHexString(CoordinatesDisplay.CONFIG.definitionColor)));
+        TextFieldWidget backgroundColor = new TextFieldWidget(this.textRenderer, this.width / 2 + p, start + (buttonHeight + p) * 3, smallButtonW, buttonHeight, Text.literal(Integer.toHexString(CoordinatesDisplay.CONFIG.definitionColor)));
 
         definitionColor.setMaxLength(6);
         dataColor.setMaxLength(6);
         deathposColor.setMaxLength(6);
-        backgroundColor.setMaxLength(6);
-        backgroundOpacity.setMaxLength(2);
+        backgroundColor.setMaxLength(8);
 
         definitionColor.setText(Integer.toHexString(CoordinatesDisplay.CONFIG.definitionColor));
         dataColor.setText(Integer.toHexString(CoordinatesDisplay.CONFIG.dataColor));
         deathposColor.setText(Integer.toHexString(CoordinatesDisplay.CONFIG.deathPosColor));
         backgroundColor.setText(Integer.toHexString(CoordinatesDisplay.CONFIG.backgroundColor));
-        backgroundOpacity.setText(Integer.toHexString(CoordinatesDisplay.CONFIG.backgroundOpacity));
 
         definitionColor.setChangedListener((txt) -> {
             if (txt.isEmpty()) return;
@@ -195,17 +190,8 @@ public class ColorConfigScreen extends Screen {
         backgroundColor.setChangedListener((txt) -> {
             if (txt.isEmpty()) return;
             try {
-                CoordinatesDisplay.CONFIG.backgroundColor = Integer.valueOf(txt.replaceAll("#", ""), 16);
-            } catch (NumberFormatException e) {
-                CoordinatesDisplay.LOGGER.error("Why you put invalid hex code?");
-                CoordinatesDisplay.LOGGER.printStackTrace(e);
-            }
-        });
-
-        backgroundOpacity.setChangedListener((txt) -> {
-            if (txt.isEmpty()) return;
-            try {
-                CoordinatesDisplay.CONFIG.backgroundOpacity = Integer.valueOf(txt.replaceAll("#", ""), 16);
+                // Need to use parseUnsignedInt in order to get ARGB values over 0x7fffffff to work
+                CoordinatesDisplay.CONFIG.backgroundColor = Integer.parseUnsignedInt(txt.replaceAll("#", ""), 16);
             } catch (NumberFormatException e) {
                 CoordinatesDisplay.LOGGER.error("Why you put invalid hex code?");
                 CoordinatesDisplay.LOGGER.printStackTrace(e);
@@ -216,9 +202,8 @@ public class ColorConfigScreen extends Screen {
         this.addDrawableChild(dataColor);
         this.addDrawableChild(deathposColor);
         this.addDrawableChild(backgroundColor);
-        this.addDrawableChild(backgroundOpacity);
 
-        this.addDrawableChild(new PressableTextWidget(this.width / 2 + p1, start + (buttonHeight + p) * 3, smallButtonW, buttonHeight, Text.literal("Color Picker..."), (button -> {
+        this.addDrawableChild(new PressableTextWidget(this.width / 2 - smallButtonW - p, start + 8 + (buttonHeight + p) * 4, smallButtonW, buttonHeight, Text.literal("Color Picker..."), (button -> {
             Util.getOperatingSystem().open("https://htmlcolorcodes.com/color-picker/");
         }), MinecraftClient.getInstance().textRenderer));
 

--- a/fabric/src/main/java/me/boxadactle/coordinatesdisplay/gui/config/ColorConfigScreen.java
+++ b/fabric/src/main/java/me/boxadactle/coordinatesdisplay/gui/config/ColorConfigScreen.java
@@ -111,7 +111,7 @@ public class ColorConfigScreen extends Screen {
         drawTextWithShadow(matrices, this.textRenderer, Text.literal("Definition Color"), this.width / 2 - smallButtonW, start + 8, ModUtils.WHITE);
         drawTextWithShadow(matrices, this.textRenderer, Text.literal("Data Color"), this.width / 2, start + 8, ModUtils.WHITE);
         drawTextWithShadow(matrices, this.textRenderer, Text.literal("Death Position Color"), this.width / 2 - smallButtonW - p, start + 8 + (buttonHeight + p) * 2, ModUtils.WHITE);
-        drawTextWithShadow(matrices, this.textRenderer, Text.literal("Background Color (ARGB)"), this.width / 2 - smallButtonW, start + 8 + (buttonHeight + p) * 4, ModUtils.WHITE);
+        drawTextWithShadow(matrices, this.textRenderer, Text.literal("Background Color"), this.width / 2 - smallButtonW, start + 8 + (buttonHeight + p) * 4, ModUtils.WHITE);
         drawTextWithShadow(matrices, this.textRenderer, Text.literal("Background Opacity"), this.width / 2, start + 8 + (buttonHeight + p) * 4, ModUtils.WHITE);
 
         CoordinatesDisplay.OVERLAY.render(matrices, pos, chunkPos, cameraYaw, null, this.width / 2 - CoordinatesDisplay.OVERLAY.getWidth() - 5, y);

--- a/fabric/src/main/java/me/boxadactle/coordinatesdisplay/util/DefaultModConfig.java
+++ b/fabric/src/main/java/me/boxadactle/coordinatesdisplay/util/DefaultModConfig.java
@@ -19,8 +19,7 @@ public class DefaultModConfig {
     public static final int definitionColor = 0x55FF55;
     public static final int dataColor = 0xFFFFFF;
     public static final int deathPosColor = 0x55FFFF;
-    public static final int backgroundColor = 0x5c5c5c;
-    public static final int backgroundOpacity = 0x60;
+    public static final int backgroundColor = 0x605c5c5c;
 
     public static final boolean displayPosOnDeathScreen = true;
     public static final boolean showDeathPosInChat = true;

--- a/fabric/src/main/java/me/boxadactle/coordinatesdisplay/util/DefaultModConfig.java
+++ b/fabric/src/main/java/me/boxadactle/coordinatesdisplay/util/DefaultModConfig.java
@@ -19,6 +19,8 @@ public class DefaultModConfig {
     public static final int definitionColor = 0x55FF55;
     public static final int dataColor = 0xFFFFFF;
     public static final int deathPosColor = 0x55FFFF;
+    public static final int backgroundColor = 0x5c5c5c;
+    public static final int backgroundOpacity = 0x60;
 
     public static final boolean displayPosOnDeathScreen = true;
     public static final boolean showDeathPosInChat = true;

--- a/fabric/src/main/java/me/boxadactle/coordinatesdisplay/util/HudOverlay.java
+++ b/fabric/src/main/java/me/boxadactle/coordinatesdisplay/util/HudOverlay.java
@@ -104,9 +104,9 @@ public class HudOverlay extends DrawableHelper {
 
         if (this.config.renderBackground) {
             if (this.getTextRenderer().getWidth(biomeText) > w || this.getTextRenderer().getWidth(directionText) > w) {
-                fill(matrices, x, y, x + p + ModUtils.getLongestLength(biomeText, directionText), y + h, ModUtils.TRANSPARENT_GRAY);
+                fill(matrices, x, y, x + p + ModUtils.getLongestLength(biomeText, directionText), y + h, CoordinatesDisplay.CONFIG.backgroundColor | (CoordinatesDisplay.CONFIG.backgroundOpacity << 24));
             } else {
-                fill(matrices, x, y, x + w, y + h, ModUtils.TRANSPARENT_GRAY);
+                fill(matrices, x, y, x + w, y + h, CoordinatesDisplay.CONFIG.backgroundColor | (CoordinatesDisplay.CONFIG.backgroundOpacity << 24));
             }
         }
 

--- a/fabric/src/main/java/me/boxadactle/coordinatesdisplay/util/HudOverlay.java
+++ b/fabric/src/main/java/me/boxadactle/coordinatesdisplay/util/HudOverlay.java
@@ -104,9 +104,9 @@ public class HudOverlay extends DrawableHelper {
 
         if (this.config.renderBackground) {
             if (this.getTextRenderer().getWidth(biomeText) > w || this.getTextRenderer().getWidth(directionText) > w) {
-                fill(matrices, x, y, x + p + ModUtils.getLongestLength(biomeText, directionText), y + h, CoordinatesDisplay.CONFIG.backgroundColor | (CoordinatesDisplay.CONFIG.backgroundOpacity << 24));
+                fill(matrices, x, y, x + p + ModUtils.getLongestLength(biomeText, directionText), y + h, CoordinatesDisplay.CONFIG.backgroundColor);
             } else {
-                fill(matrices, x, y, x + w, y + h, CoordinatesDisplay.CONFIG.backgroundColor | (CoordinatesDisplay.CONFIG.backgroundOpacity << 24));
+                fill(matrices, x, y, x + w, y + h, CoordinatesDisplay.CONFIG.backgroundColor);
             }
         }
 

--- a/fabric/src/main/java/me/boxadactle/coordinatesdisplay/util/ModConfig.java
+++ b/fabric/src/main/java/me/boxadactle/coordinatesdisplay/util/ModConfig.java
@@ -19,6 +19,8 @@ public class ModConfig {
     public int definitionColor = DefaultModConfig.definitionColor;
     public int dataColor = DefaultModConfig.dataColor;
     public int deathPosColor = DefaultModConfig.deathPosColor;
+    public int backgroundColor = DefaultModConfig.backgroundColor;
+    public int backgroundOpacity = DefaultModConfig.backgroundOpacity;
 
     public boolean displayPosOnDeathScreen = DefaultModConfig.displayPosOnDeathScreen;
     public boolean showDeathPosInChat = DefaultModConfig.displayPosOnDeathScreen;

--- a/fabric/src/main/java/me/boxadactle/coordinatesdisplay/util/ModConfig.java
+++ b/fabric/src/main/java/me/boxadactle/coordinatesdisplay/util/ModConfig.java
@@ -20,7 +20,6 @@ public class ModConfig {
     public int dataColor = DefaultModConfig.dataColor;
     public int deathPosColor = DefaultModConfig.deathPosColor;
     public int backgroundColor = DefaultModConfig.backgroundColor;
-    public int backgroundOpacity = DefaultModConfig.backgroundOpacity;
 
     public boolean displayPosOnDeathScreen = DefaultModConfig.displayPosOnDeathScreen;
     public boolean showDeathPosInChat = DefaultModConfig.displayPosOnDeathScreen;

--- a/fabric/src/main/java/me/boxadactle/coordinatesdisplay/util/ModUtils.java
+++ b/fabric/src/main/java/me/boxadactle/coordinatesdisplay/util/ModUtils.java
@@ -23,7 +23,6 @@ import java.util.Locale;
 
 public class ModUtils {
 
-    public static final int TRANSPARENT_GRAY = 0x5c5c5c60;
     public static final int WHITE = 16777215;
     public static final int GRAY = 	11184810;
     public static final int DARK_GRAY = 5592405;


### PR DESCRIPTION
This adds the ability to change the Background Color and Opacity for Fabric

I am not familiar with Forge so I did not implement it there. It also seems there were other limitations with forge due to only supporting vanilla colors at the moment. Not sure how important feature parity is but it seems the Fabric version is already more feature-rich when it comes to color selection.

Closes #12 

<img width="841" alt="image" src="https://user-images.githubusercontent.com/16939084/223016503-fbfc8a84-1308-42a1-a5c5-e057261ddf6e.png">
 